### PR TITLE
[WIP] Add setuptools and wheel to pre-requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ i-MSCP accounts to one KeyHelp account.
 
 ## Installation packages
 ```
-apt-get install pv sshpass python3-pip python3-requests python3-paramiko python3-distutils-extra python3-tqdm
+apt-get install pv sshpass python3-pip python3-requests python3-paramiko python3-distutils-extra python3-tqdm python3-setuptools python3-wheel
 python3 -m pip install mysql-connector inquirer
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ If you get some messages like the following while running the migration script:
 ```
 CryptographyDeprecationWarning: Support for unsafe construction of public numbers from encoded data will be removed in a future version
 ```
-Upgrade the package "paramiko" to version 2.5.0
+Upgrade the package "paramiko" to at least version 2.5.0
 ```
-pip3 install paramiko==2.5.0
+pip3 install "paramiko>=2.5.0"
 ```
 
 ## How to use the migration script


### PR DESCRIPTION
Hi, first of all thank you very much for making this tool available! I'm currently going through the steps to get this running and noticed setuptools and wheel were missing from the pre-requirement install command. The pip install command wouldn't run through without these, at least on the clean Debian 10 install I'm testing this on. I'll add more changes to this PR if I run across anything else!